### PR TITLE
Use npm ci --ignore-scripts in CI workflow

### DIFF
--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -65,7 +65,7 @@ jobs:
           node-version: '12'
 
       - name: Install NPM Packages
-        run: npm install
+        run: npm ci --ignore-scripts
 
       - name: Check JS & CSS syntax
         run: npm run lint


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci --ignore-scripts` in wordpress.yml
- Prevents execution of postinstall/lifecycle scripts during CI, mitigating supply chain attacks
- No functional impact: CI doesn't need husky hooks or other lifecycle scripts

## Test plan
- [ ] Lint/test jobs still pass
- [ ] Deploy workflow still builds correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)