### PR TITLE
Add Playground preview workflows

### DIFF
--- a/.github/workflows/playground-preview-build.yml
+++ b/.github/workflows/playground-preview-build.yml
@@ -1,0 +1,17 @@
+name: Playground Preview - Build
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'playground') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'playground')
+    uses: tarosky/workflows/.github/workflows/playground-preview-build.yml@main
+    with:
+      build_command: 'npm ci --ignore-scripts && npm run package'

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -1,0 +1,18 @@
+name: Playground Preview - Publish
+
+on:
+  workflow_run:
+    workflows: ["Playground Preview - Build"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    uses: tarosky/workflows/.github/workflows/playground-preview-publish.yml@main


### PR DESCRIPTION
## Summary
- Add Playground preview build/publish workflows
- PRs labeled with `playground` will get a WordPress Playground preview link as a comment
- Uses shared workflows from tarosky/workflows
- Custom build_command: `npm ci --ignore-scripts && npm run package` (no composer needed for production)

## Test plan
- [ ] Create a test PR, add `playground` label, verify preview link appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)